### PR TITLE
Fix servo calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,216 @@
+# Castles & Cans
+
+This repository contains an early prototype of **Castles & Cans**, an interactive castle-themed drinking game powered by a Raspberry Pi.
+
+The game uses a touchscreen user interface and communicates with physical components such as sensors, lights and motors. Two teams (Red and Green) compete by hitting targets and triggering challenges.
+
+At this stage the project includes a simple Python program (`src/game.py`) implementing the basic UI and placeholder hardware actions.
+
+## Running
+
+Ensure Python 3 with Tkinter is installed. Launch the prototype with:
+
+```bash
+python3 src/game.py
+```
+
+The UI requires an X11 display. If no display is available the script will exit
+with an error message. When running over SSH be sure to enable X forwarding or
+attach a screen to the Pi.
+
+The window now features a medieval-style colour scheme with parchment text on a
+dark stone background. Photos captured by the Pi camera slide in from the bottom
+to fill the entire screen with the status text overlaid in the centre. The layout
+fits the 800×480 Pi touchscreen so previews no longer spill off the edges. The
+photo overlay now animates smoothly with centred text, stays visible for three seconds
+and hides automatically.
+
+The game logic lives in `src/game.py`.  It drives the user interface and
+simulated hardware while tracking each team's progress.  The program cycles
+through a number of **states**:
+
+* `WAITING_START` – initial idle state
+* `COIN_FLIP` – choose the starting team
+* `PLAYER_TURN` – wait for the team to hit its required target
+* `AWAITING_TUNNEL` – target hit, waiting for the ball to enter the tunnel
+* `AWAITING_LAUNCH` – tunnel triggered, countdown before launch
+* `BALL_LAUNCHED` – ball launched but no chugging
+* `CHUG` – active chug phase after a successful hit
+* `GAME_OVER` – all targets complete
+
+This will open a window demonstrating the UI flow: start/reset, coin flip and alternating turns. The window displays which randomly-chosen target is required along with each team's progress. Each team must complete all seven targets once. Hitting the wrong target simply plays a neutral effect. Once the proper target is cleared the game waits for the tunnel sensor. A couple of seconds after the tunnel triggers the screen shows **Ready to launch**. Press the launch key to fire the plunger. Chugging only begins once the ball is launched and stops when it is returned.
+
+### Keyboard controls
+
+The prototype uses keyboard keys to mimic hardware buttons:
+
+- **s** – Start or reset the game
+- **n** – Force next turn
+- **r** – Dispense beer for the Red team (Servo 1 counterclockwise, opens the Red door)
+- **g** – Dispense beer for the Green team (Servo 2 clockwise, opens the Green door)
+- **1**..**7** – Trigger target sensors (registers a hit only when it matches the current team's assigned target)
+- **y** – Simulate the IR sensor completing Target 1
+- **l** – Launch the ball after the tunnel is triggered
+- **b** – Signal that the ball returned
+- **t** – Tunnel sensor triggered (prepares launch)
+- **f** – Blow the fan for five seconds to clear the tube
+
+Each team has its own beer door on the castle. The Red door is driven by **Servo 1** and the Green door by **Servo 2**. Pressing the matching dispense button or key opens that team's door for three seconds before closing it again.
+
+When running on a Raspberry Pi with GPIO enabled, the IR sensors connected to
+**IR_TUNNEL_ENTRY** (BCM 15) and **IR_BALL_RETURN** (BCM 14) automatically
+trigger the same actions as the **t** and **b** keys.
+
+Likewise the physical buttons are mapped to their keyboard equivalents:
+the single Start/Reset button acts like **s**, the Force Next Turn button like
+**n**, and the dispense buttons match **r** and **g**.  These buttons should
+be wired between the Pi's 3.3 V rail and the respective GPIO pin; the
+script enables the internal pull‑down resistors so a press registers as a
+RISING edge.
+Console messages like ``[GPIO] Start button pressed`` confirm that the
+callbacks are firing. If no message appears when pressing a button,
+double-check the wiring (3.3 V → button → GPIO) and that the script is
+running on a Pi with ``RPi.GPIO`` installed.
+
+Dispensing a beer moves the tap servos. Pressing the Red button opens the red door by rotating **Servo 1** 100° counterclockwise while the Green button opens the green door by rotating **Servo 2** 100° clockwise. Each servo automatically returns to centre after three seconds.
+Servo angles are recognised from **0–180°**. Use the `calibrate` command to set each servo's starting angle if needed. Movements default to around 180°/s but can be slowed using the optional ``speed`` parameter of the `servo` command.
+
+Servo positions and starting angles are saved to `servo_state.json`. On startup
+and whenever a new game begins, the program restores each servo to its saved
+starting angle only if necessary. This helps avoid sudden movements if the Pi
+loses power mid-game.
+
+Team progress is stored separately, and the hardware is instructed to restore
+each side's targets whenever turns change.
+
+A missed shot automatically ends the turn once the ball is returned.
+
+Basic GPIO support is now included using BCM pin numbering. When the script
+detects the RPi.GPIO library it configures each pin as described below;
+otherwise the hardware actions are simply printed for testing on other
+systems.
+
+### Command interface
+
+When running the prototype from a terminal you can also type commands to
+manually trigger sensors or move servos. Type `help` at any time to list
+available commands. Commands are processed in the background so the UI
+remains responsive. Useful commands include:
+
+```
+help                  # show available commands
+servo <n> <angle> [speed]  # rotate servo n to angle (speed deg/s)
+calibrate <n> <angle>      # set servo n's starting angle
+sensitivity <ch> <val>     # adjust pressure sensor threshold
+watchtower_pressure        # simulate the watchtower pressure sensor
+watchtower_ir              # simulate the watchtower IR detector
+hit <n>                    # trigger target n
+tunnel                     # activate the tunnel sensor
+launch                     # fire the plunger when ready
+return                     # signal the ball return sensor
+dispense <red|green>       # open a beer door
+```
+
+Specify a slower ``speed`` to move a servo gradually. For example
+`servo 3 50 20` rotates servo 3 to 50° at 20 °/s. The keyboard shortcuts
+listed above still work alongside these commands.
+
+### Camera captures and uploads
+
+When a target is hit, the Pi camera snaps a photo that slides onto the screen while the game prepares to launch the ball. Another photo is taken a couple of seconds into the chug phase and displayed full screen when the ball returns. These images are automatically uploaded using **rclone** but remain in the `captures` directory for the rest of the session. Old captures are cleaned up whenever the program starts.
+
+The script looks for either `libcamera-still` or `raspistill` to capture photos at **1280×720**. The `--immediate` option is used with `libcamera-still` to minimise shutter lag and photos are captured in a background thread so the UI remains responsive. If neither command is available the program creates placeholder images instead.
+
+Set the environment variable `RCLONE_REMOTE` to the destination configured in rclone, for example `mydrive:CastlesAndCans`. If the variable is missing or rclone is not installed, uploads are skipped.
+
+Only the Pillow package is required for displaying images:
+
+```bash
+pip install Pillow
+```
+
+The Pillow package must include ImageTk support. On some systems this requires the `python3-pil.imagetk` package or similar.
+
+### RClone setup
+
+1. Install rclone on the Pi. You can use `sudo apt install rclone` or follow the instructions on [rclone.org](https://rclone.org/install/).
+2. Run `rclone config` and create a remote for Google Drive (or another provider). Note the remote name.
+3. Create or choose a folder on your remote to store uploads.
+4. Set `RCLONE_REMOTE` to `<remote>:<folder>` (for example `gdrive:CastlesAndCans`).
+5. Run the prototype and check the console for `[RClone] Uploader configured for ...`.
+
+### Pressure sensors
+
+Four thin-film force sensors attach to the MCP3008 ADC on channels 0–3.  The
+game polls these inputs in the background and logs a hit whenever the reading
+exceeds a sensitivity threshold.  Hits are counted per channel for future
+expansion.
+
+Target 1 is a small watchtower. Hitting the front pressure sensor (channel 0)
+rotates **Servo 3** 40° counterclockwise at a slow speed to "topple" the tower
+and reveal an infrared beam inside. When that beam (``IR_TARGET_1``) is broken,
+the target is marked complete and the servo returns to its starting position.
+
+Each pressure sensor has its own threshold saved in `pressure_sensitivity.json`.
+Use the command `sensitivity <channel> <value>` to fine tune a channel and the
+value will be saved for future runs.
+
+### Hardware actions
+
+`HardwareInterface` in `src/game.py` abstracts every output the real game will
+control.  When running on a desktop these methods simply print messages so the
+logic can be tested without wiring anything up.  It also includes helper
+functions for playing sounds and driving LEDs so the high-level logic stays the
+same once real hardware is connected. The key actions are:
+
+| Method | Purpose |
+|--------|---------|
+| `blow_fan(duration)` | Pulse the fan relay to clear the ball return tube |
+| `start_chug(team)` and `stop_chug(team)` | Start or stop the chug phase |
+| `hit_target(n)` | Flash lights or play a sound for target `n` |
+| `drop_gate()` | Release the castle gate on victory |
+| `dispense(team)` | Open the team's beer door (Servo 1 for Red, Servo 2 for Green) |
+| `activate_tunnel(n)` | Indicate a ball has entered tunnel `n` |
+| `launch_plunger()` | Fire the plunger to launch the ball |
+| `restore_targets(team, hits)` | Reset physical targets to a team's progress |
+| `play_sound(effect)` | Play an audio effect |
+| `set_target_led(target, color)` | Change a target's indicator LED |
+| `set_theme_lighting(team)` | Adjust theme lighting for the active team |
+| `raise_pong_platform()` | Raise the pong platform on victory |
+
+These helper methods allow the software to run headless or on different
+hardware by adjusting only the implementation in one place.
+
+### GPIO Pin Assignments
+
+The table below lists the BCM GPIO pins used by the project. The Python script
+initialises these pins automatically when RPi.GPIO is available.
+
+| Component                | BCM Pin | Header Pin | Notes |
+|--------------------------|---------|------------|-------|
+| RELAY_FAN                | 17      | 11         | Fan to clear tube |
+| RELAY_RED_DISPENSE       | 5       | 29         | Controls Red beer valve |
+| RELAY_GREEN_DISPENSE     | 6       | 31         | Controls Green beer valve |
+| RELAY_EXPANSION_1        | 13      | 33         | Spare relay |
+| RELAY_EXPANSION_2        | 19      | 35         | Spare relay |
+| RELAY_EXPANSION_3        | 26      | 37         | Spare relay |
+| NEOPIXEL_PIN             | 18      | 12         | Addressable LEDs |
+| BUTTON_START/RESET       | 23      | 16         | Start or reset game |
+| BUTTON_FORCE_TURN        | 24      | 18         | Force next turn |
+| BUTTON_RED_DISPENSE      | 20      | 38         | Dispense Red beer |
+| BUTTON_GREEN_DISPENSE    | 21      | 40         | Dispense Green beer |
+| IR_BALL_RETURN           | 14      | 8          | Detect ball return |
+| IR_TUNNEL_ENTRY          | 15      | 10         | Detect tunnel entry |
+| IR_TARGET_1              | 0       | 27         | Watchtower IR sensor |
+| MCP3008_CLK              | 11      | 23         | SPI clock |
+| MCP3008_MISO             | 9       | 21         | SPI MISO |
+| MCP3008_MOSI             | 10      | 19         | SPI MOSI |
+| MCP3008_CS               | 8       | 24         | SPI chip select |
+| SERVO_1                  | 12      | 32         | Red team beer door |
+| SERVO_2                  | 16      | 36         | Green team beer door |
+| SERVO_3                  | 4       | 7          | Watchtower rotation |
+| SERVO_4                  | 3       | 5          | (unassigned) |
+| SERVO_5                  | 2       | 3          | (unassigned) |
+| SERVO_6                  | 27      | 13         | (unassigned) |
+| SERVO_7                  | 22      | 15         | (unassigned) |
+| SERVO_8                  | 7       | 26         | (unassigned) |

--- a/src/game.py
+++ b/src/game.py
@@ -1,0 +1,1218 @@
+# Game logic and UI for Castles & Cans
+# Placeholder implementation for Raspberry Pi hardware integration
+
+import os
+import random
+import datetime
+import tkinter as tk
+from enum import Enum, auto
+from typing import Optional
+import subprocess
+import shutil
+import sys
+import threading
+import time
+import json
+
+try:
+    import RPi.GPIO as GPIO
+    GPIO.setmode(GPIO.BCM)
+    GPIO.setwarnings(False)
+    GPIO_AVAILABLE = True
+except Exception as exc:
+    GPIO_AVAILABLE = False
+    print(f"[GPIO] Hardware GPIO unavailable: {exc}")
+
+try:
+    import spidev
+    SPI_AVAILABLE = True
+except Exception as exc:
+    spidev = None
+    SPI_AVAILABLE = False
+    print(f"[SPI] spidev unavailable: {exc}")
+
+try:
+    from PIL import Image, ImageTk  # Requires Pillow and ImageTk support
+except Exception as exc:  # Pillow may be missing or compiled without tkinter
+    Image = None
+    ImageTk = None
+    print(f"[Init] Pillow ImageTk unavailable: {exc}")
+
+# Basic colors and fonts for a castle-style theme
+BG_COLOR = "#352f2b"  # dark stone background
+FG_COLOR = "#f0e6c8"  # parchment text
+BUTTON_BG = "#5b4636"
+TITLE_FONT = ("Times New Roman", 30, "bold")
+LABEL_FONT = ("Times New Roman", 18, "bold")
+BUTTON_FONT = ("Times New Roman", 16, "bold")
+PROGRESS_FONT = ("Times New Roman", 24, "bold")
+
+NUM_TARGETS = 7
+
+# ---------------- GPIO PIN ASSIGNMENTS ----------------
+# BCM numbering is used throughout
+RELAY_FAN = 17
+RELAY_RED_DISPENSE = 5
+RELAY_GREEN_DISPENSE = 6
+RELAY_EXPANSION_1 = 13
+RELAY_EXPANSION_2 = 19
+RELAY_EXPANSION_3 = 26
+
+NEOPIXEL_PIN = 18
+
+BUTTON_START = 23
+# Start and Reset share the same button
+BUTTON_FORCE_TURN = 24
+BUTTON_RED_DISPENSE = 20
+BUTTON_GREEN_DISPENSE = 21
+
+IR_BALL_RETURN = 14
+IR_TUNNEL_ENTRY = 15
+IR_TARGET_1 = 0
+
+MCP3008_CLK = 11
+MCP3008_MISO = 9
+MCP3008_MOSI = 10
+MCP3008_CS = 8
+
+SERVO_1 = 12  # Red team beer door
+SERVO_2 = 16  # Green team beer door
+SERVO_3 = 4
+SERVO_4 = 3
+SERVO_5 = 2
+SERVO_6 = 27
+SERVO_7 = 22
+SERVO_8 = 7
+
+# Pressure sensors via MCP3008 channels
+PRESSURE_CHANNELS = [0, 1, 2, 3]
+PRESSURE_SENSITIVITY_DEFAULT = 200  # Default ADC threshold for detecting a hit
+
+class Team(Enum):
+    RED = 'Red'
+    GREEN = 'Green'
+
+
+class GameState(Enum):
+    WAITING_START = auto()
+    COIN_FLIP = auto()
+    PLAYER_TURN = auto()
+    AWAITING_TUNNEL = auto()
+    AWAITING_LAUNCH = auto()
+    BALL_LAUNCHED = auto()
+    CHUG = auto()
+    GAME_OVER = auto()
+
+
+class SoundEffect(Enum):
+    """Logical names for sound effects used throughout the game."""
+    TARGET_HIT = auto()
+    NEUTRAL_HIT = auto()
+    CHUG_START = auto()
+    CHUG_STOP = auto()
+    GATE_BREACH = auto()
+    VICTORY = auto()
+    DISPENSE = auto()
+
+
+class LedColor(Enum):
+    """Placeholder LED colours."""
+    RED = 'red'
+    GREEN = 'green'
+    OFF = 'off'
+
+
+class HardwareInterface:
+    """Basic GPIO control for the Castles & Cans hardware."""
+
+    SERVO_STATE_FILE = "servo_state.json"
+    PRESSURE_FILE = "pressure_sensitivity.json"
+    DEFAULT_START_ANGLE = 90
+    MAX_ANGLE = 180
+
+    def __init__(self, pressure_sensitivity: int = PRESSURE_SENSITIVITY_DEFAULT):
+        self.available = GPIO_AVAILABLE
+        self.spi_available = SPI_AVAILABLE
+        self.pressure_sensitivity = {ch: pressure_sensitivity for ch in PRESSURE_CHANNELS}
+        self.servo_pins = [
+            SERVO_1,
+            SERVO_2,
+            SERVO_3,
+            SERVO_4,
+            SERVO_5,
+            SERVO_6,
+            SERVO_7,
+            SERVO_8,
+        ]
+        # Map BCM pins back to servo numbers for clearer logs
+        self.servo_numbers = {pin: i + 1 for i, pin in enumerate(self.servo_pins)}
+        if self.available:
+            outputs = [
+                RELAY_FAN,
+                RELAY_RED_DISPENSE,
+                RELAY_GREEN_DISPENSE,
+                RELAY_EXPANSION_1,
+                RELAY_EXPANSION_2,
+                RELAY_EXPANSION_3,
+            ]
+            for pin in outputs:
+                GPIO.setup(pin, GPIO.OUT, initial=GPIO.LOW)
+                print(f"[GPIO] Output {pin} initialised LOW")
+
+            for pin in [
+                BUTTON_START,
+                BUTTON_FORCE_TURN,
+                BUTTON_RED_DISPENSE,
+                BUTTON_GREEN_DISPENSE,
+            ]:
+                GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+                print(f"[GPIO] Input {pin} set with pull-down")
+
+            for pin in [IR_BALL_RETURN, IR_TUNNEL_ENTRY, IR_TARGET_1]:
+                GPIO.setup(pin, GPIO.IN, pull_up_down=GPIO.PUD_DOWN)
+                print(f"[GPIO] Input {pin} set with pull-down")
+
+            for pin in [
+                SERVO_1,
+                SERVO_2,
+                SERVO_3,
+                SERVO_4,
+                SERVO_5,
+                SERVO_6,
+                SERVO_7,
+                SERVO_8,
+            ]:
+                GPIO.setup(pin, GPIO.OUT)
+                print(f"[GPIO] Servo {pin} output setup")
+        else:
+            print("[GPIO] Running in mock mode")
+
+        # SPI setup for MCP3008
+        if self.spi_available:
+            try:
+                self.spi = spidev.SpiDev()
+                self.spi.open(0, 0)
+                self.spi.max_speed_hz = 1350000
+            except Exception as exc:
+                print(f"[SPI] Failed to open SPI: {exc}")
+                self.spi_available = False
+        else:
+            print("[SPI] Using mock ADC readings")
+
+        self._load_servo_state()
+        self._load_pressure_sensitivity()
+        self.reset_servos()
+
+    def _load_servo_state(self):
+        """Load servo positions and start angles from disk."""
+        self.servo_state = {pin: self.DEFAULT_START_ANGLE for pin in self.servo_pins}
+        self.servo_start = {pin: self.DEFAULT_START_ANGLE for pin in self.servo_pins}
+        if os.path.exists(self.SERVO_STATE_FILE):
+            try:
+                with open(self.SERVO_STATE_FILE, "r") as fh:
+                    data = json.load(fh)
+                if "positions" in data and "start_angles" in data:
+                    positions = data.get("positions", {})
+                    starts = data.get("start_angles", {})
+                else:
+                    positions = data
+                    starts = {}
+                for pin in self.servo_pins:
+                    if str(pin) in positions:
+                        self.servo_state[pin] = positions[str(pin)]
+                    if str(pin) in starts:
+                        self.servo_start[pin] = starts[str(pin)]
+            except Exception as exc:
+                print(f"[Servo] Failed to load state: {exc}")
+
+    def _load_pressure_sensitivity(self):
+        """Load per-channel pressure sensor thresholds from disk."""
+        if os.path.exists(self.PRESSURE_FILE):
+            try:
+                with open(self.PRESSURE_FILE, "r") as fh:
+                    data = json.load(fh)
+                for ch in PRESSURE_CHANNELS:
+                    if str(ch) in data:
+                        self.pressure_sensitivity[ch] = int(data[str(ch)])
+            except Exception as exc:
+                print(f"[Pressure] Failed to load sensitivity: {exc}")
+        else:
+            self._save_pressure_sensitivity()
+
+    def _save_pressure_sensitivity(self):
+        try:
+            with open(self.PRESSURE_FILE, "w") as fh:
+                json.dump({str(ch): self.pressure_sensitivity.get(ch, PRESSURE_SENSITIVITY_DEFAULT) for ch in PRESSURE_CHANNELS}, fh)
+        except Exception as exc:
+            print(f"[Pressure] Failed to save sensitivity: {exc}")
+
+    def set_pressure_sensitivity(self, channel: int, threshold: int):
+        if channel not in PRESSURE_CHANNELS:
+            raise ValueError(f"Channel {channel} not in PRESSURE_CHANNELS")
+        self.pressure_sensitivity[channel] = int(threshold)
+        self._save_pressure_sensitivity()
+
+    def _save_servo_state(self):
+        try:
+            with open(self.SERVO_STATE_FILE, "w") as fh:
+                json.dump({"positions": self.servo_state, "start_angles": self.servo_start}, fh)
+        except Exception as exc:
+            print(f"[Servo] Failed to save state: {exc}")
+
+    def set_servo_angle(self, pin: int, angle: float, speed: float = 180.0):
+        """Move servo to ``angle`` within 0–180° using optional ``speed``.
+
+        ``speed`` is given in degrees per second; lower values move the servo
+        more slowly. The movement happens asynchronously so the UI remains
+        responsive.
+        """
+
+        ang = max(0, min(angle, self.MAX_ANGLE))
+
+        def worker():
+            start = self.servo_state.get(pin, self.DEFAULT_START_ANGLE)
+            duration = abs(ang - start) / speed if speed > 0 else 0
+            if self.available:
+                pwm = GPIO.PWM(pin, 50)
+                pwm.start(self._angle_to_duty(start))
+                self._move_servo(pwm, start, ang, duration)
+                time.sleep(0.1)
+                pwm.stop()
+            num = self.servo_numbers.get(pin, pin)
+            print(f"[GPIO] Servo {num} (pin {pin}) -> {ang}° at {speed}°/s")
+
+        threading.Thread(target=worker, daemon=True).start()
+        self.servo_state[pin] = ang
+        self._save_servo_state()
+
+    def reset_servos(self):
+        """Return all servos to their configured starting angle if needed."""
+        for pin in self.servo_pins:
+            start = self.servo_start.get(pin, self.DEFAULT_START_ANGLE)
+            if self.servo_state.get(pin, start) != start:
+                self.set_servo_angle(pin, start)
+
+    @staticmethod
+    def _angle_to_duty(angle: float) -> float:
+        """Convert a 0–180° angle to a PWM duty cycle."""
+        ang = max(0, min(angle, HardwareInterface.MAX_ANGLE))
+        return 2.5 + (ang / 18.0)
+
+    def rotate_servo(
+        self,
+        pin: int,
+        angle: float,
+        hold: float = 0,
+        return_angle: float = 90,
+        speed: float = 180.0,
+    ):
+        """Rotate a servo and optionally return it.
+
+        ``speed`` controls how quickly the servo moves in degrees per second.
+        """
+
+        start = max(0, min(angle, self.MAX_ANGLE))
+        end = max(0, min(return_angle, self.MAX_ANGLE))
+
+        def worker():
+            current = self.servo_state.get(pin, self.DEFAULT_START_ANGLE)
+            move_time = abs(start - current) / speed if speed > 0 else 0
+            return_time = abs(end - start) / speed if speed > 0 else 0
+            if self.available:
+                pwm = GPIO.PWM(pin, 50)
+                pwm.start(self._angle_to_duty(current))
+                self._move_servo(pwm, current, start, move_time)
+                if hold:
+                    time.sleep(hold)
+                self._move_servo(pwm, start, end, return_time)
+                time.sleep(0.1)
+                pwm.stop()
+            num = self.servo_numbers.get(pin, pin)
+            print(
+                f"[GPIO] Servo {num} (pin {pin}) rotate {start}° for {hold}s then {end}° at {speed}°/s"
+            )
+
+        threading.Thread(target=worker, daemon=True).start()
+        self.servo_state[pin] = end
+        self._save_servo_state()
+
+    def _move_servo(self, pwm, start: float, end: float, duration: float):
+        """Gradually move ``pwm`` from ``start`` to ``end`` over ``duration`` seconds."""
+        steps = max(1, int(abs(end - start)))
+        step_delay = duration / steps if steps else 0
+        step_angle = (end - start) / steps if steps else 0
+        angle = start
+        for _ in range(steps):
+            angle += step_angle
+            pwm.ChangeDutyCycle(self._angle_to_duty(angle))
+            if step_delay:
+                time.sleep(step_delay)
+
+
+    def _pulse(self, pin: int, duration: float = 0.5):
+        """Pulse a GPIO output without blocking the main thread."""
+
+        def worker():
+            if self.available:
+                GPIO.output(pin, GPIO.HIGH)
+                time.sleep(duration)
+                GPIO.output(pin, GPIO.LOW)
+            print(f"[GPIO] Pulse {pin} for {duration}s")
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    # ---------------- MCP3008 Pressure Sensor Helpers ----------------
+    def read_adc(self, channel: int) -> int:
+        """Read a value from the MCP3008 ADC."""
+        if not 0 <= channel <= 7:
+            raise ValueError("ADC channel must be 0-7")
+        if self.spi_available:
+            try:
+                r = self.spi.xfer2([1, (8 + channel) << 4, 0])
+                return ((r[1] & 3) << 8) | r[2]
+            except Exception as exc:
+                print(f"[SPI] Read failed: {exc}")
+                return 0
+        else:
+            # No SPI available; return zero to avoid false hits
+            return 0
+
+    def check_pressure_hit(self, channel: int) -> bool:
+        """Return True if the pressure sensor crosses the configured threshold."""
+        value = self.read_adc(channel)
+        threshold = self.pressure_sensitivity.get(channel, PRESSURE_SENSITIVITY_DEFAULT)
+        if value > threshold:
+            print(f"[Pressure] Channel {channel} hit value {value}")
+            return True
+        return False
+
+    def play_sound(self, effect: SoundEffect):
+        """Play a sound effect."""
+        print(f"[Sound] {effect.name}")
+
+    def set_target_led(self, target: int, color: LedColor):
+        """Set an LED colour for a specific target."""
+        print(f"[LED] Target {target} -> {color.value}")
+
+    def set_theme_lighting(self, team: Optional[Team]):
+        """Change theme lighting to match the active team or turn off."""
+        value = team.value if team else 'off'
+        print(f"[LED] Theme lighting -> {value}")
+
+    def raise_pong_platform(self):
+        """Raise the pong platform on victory."""
+        self._pulse(RELAY_EXPANSION_2, 1)
+        print("[HW] RAISE_PONG_PLATFORM")
+
+    def blow_fan(self, duration: float = 5.0):
+        """Activate the fan relay for the specified duration."""
+        self._pulse(RELAY_FAN, duration)
+
+    def start_chug(self, team: Team):
+        print(f"[HW] START_CHUG for {team.value}")
+
+    def stop_chug(self, team: Team):
+        print(f"[HW] STOP_CHUG for {team.value}")
+
+    def hit_target(self, target: int):
+        print(f"[HW] HIT_TARGET_{target}")
+
+    def drop_gate(self):
+        print("[HW] DROP_GATE")
+
+    def dispense(self, team: Team):
+        pin = RELAY_RED_DISPENSE if team == Team.RED else RELAY_GREEN_DISPENSE
+        self._pulse(pin, 1)
+        if team == Team.RED:
+            servo_pin = SERVO_1
+            angle = 0  # 100° counterclockwise from centre
+        else:
+            servo_pin = SERVO_2
+            angle = 180  # 100° clockwise from centre (clamped)
+        self.rotate_servo(servo_pin, angle, hold=3)
+
+    def activate_tunnel(self, tunnel: int):
+        print(f"[HW] ACTIVATE_TUNNEL_{tunnel}")
+
+    def launch_plunger(self):
+        """Fire the plunger to launch the ball."""
+        self._pulse(RELAY_EXPANSION_1, 0.2)
+        print("[HW] LAUNCH_PLUNGER")
+
+    def restore_targets(self, team: Team, hits: int):
+        """Reset physical targets to the given hit count."""
+        print(f"[HW] RESTORE_TARGETS for {team.value} at hit count {hits}")
+
+
+class CameraInterface:
+    """Handle capturing images from the Pi camera."""
+
+    def __init__(self, capture_dir: str = "captures"):
+        self.capture_dir = capture_dir
+        os.makedirs(self.capture_dir, exist_ok=True)
+        # Remove any leftover captures from a previous run
+        for f in os.listdir(self.capture_dir):
+            if f.lower().endswith(".jpg"):
+                try:
+                    os.remove(os.path.join(self.capture_dir, f))
+                except OSError as exc:
+                    print(f"[Camera] Failed to remove old capture {f}: {exc}")
+
+        # Determine which camera command is available on the system.
+        self.command = None
+        if shutil.which("libcamera-still"):
+            # ``libcamera-still`` is the default on newer Pi OS releases
+            self.command = [
+                "libcamera-still",
+                "-n",
+                "--immediate",
+                "--width",
+                "1280",
+                "--height",
+                "720",
+                "-o",
+            ]
+        elif shutil.which("raspistill"):
+            # ``raspistill`` for legacy camera stack
+            self.command = [
+                "raspistill",
+                "-n",
+                "-t",
+                "1",
+                "-w",
+                "1280",
+                "-h",
+                "720",
+                "-o",
+            ]
+        else:
+            print("[Camera] No camera command found. Using placeholder images")
+
+    def _placeholder_image(self, path: str):
+        """Create a blank placeholder image when the camera is unavailable."""
+        if Image:
+            img = Image.new("RGB", (1280, 720), color="black")
+            img.save(path)
+        else:
+            with open(path, "wb"):
+                pass
+
+    def capture_image(self, prefix: str) -> str:
+        """Capture an image and return the file path."""
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"{prefix}_{timestamp}.jpg"
+        path = os.path.join(self.capture_dir, filename)
+
+        if self.command:
+            try:
+                subprocess.check_call(
+                    self.command + [path],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                )
+            except Exception as exc:
+                print(f"[Camera] Failed to capture image: {exc}")
+                self._placeholder_image(path)
+        else:
+            self._placeholder_image(path)
+
+        return path
+
+
+class RCloneUploader:
+    """Upload files using rclone and remove them locally."""
+
+    def __init__(self, remote: Optional[str] = None):
+        self.remote = remote
+        self.enabled = False
+        if not remote:
+            print("[RClone] RCLONE_REMOTE not set. Upload disabled")
+            return
+        if shutil.which("rclone") is None:
+            print("[RClone] rclone command not found. Upload disabled")
+            return
+        self.enabled = True
+        print(f"[RClone] Uploader configured for {self.remote}")
+
+    def upload(self, filepath: str):
+        if not self.enabled:
+            print("[RClone] Upload skipped - uploader not configured")
+            return
+
+        try:
+            subprocess.check_call(["rclone", "copy", filepath, self.remote])
+            print(f"[RClone] Uploaded {filepath}")
+        except Exception as exc:
+            print(f"[RClone] Failed to upload {filepath}: {exc}")
+        finally:
+            pass
+
+
+class CastlesAndCansGame:
+    def __init__(self, root: tk.Tk):
+        self.root = root
+        self.state = GameState.WAITING_START
+        self.hw = HardwareInterface()
+        self.current_team = None
+        self.completed_targets = {Team.RED: set(), Team.GREEN: set()}
+        self.current_target = {Team.RED: None, Team.GREEN: None}
+        self.awaiting_tunnel = False
+        self.prev_status = ""
+        self.camera = CameraInterface()
+        self.drive = RCloneUploader(os.environ.get("RCLONE_REMOTE"))
+        self.chug_photo = None
+        self.pressure_hits = {ch: 0 for ch in PRESSURE_CHANNELS}
+        self._pressure_state = {ch: False for ch in PRESSURE_CHANNELS}
+        self.watchtower_active = False
+        self.setup_ui()
+        # Bind all key events so they register regardless of focus
+        self.root.bind_all('<Key>', self.handle_key)
+        self.ball_in_play = False
+
+        # Map servo numbers to pins for the command interface
+        self.servo_map = {i + 1: pin for i, pin in enumerate(self.hw.servo_pins)}
+
+        # Hook up GPIO callbacks for tunnel and ball return sensors
+        if self.hw.available:
+            try:
+                GPIO.add_event_detect(
+                    IR_TUNNEL_ENTRY,
+                    GPIO.RISING,
+                    callback=self._gpio_tunnel,
+                    bouncetime=200,
+                )
+                print(f"[GPIO] Event detect added for tunnel on pin {IR_TUNNEL_ENTRY}")
+                GPIO.add_event_detect(
+                    IR_BALL_RETURN,
+                    GPIO.RISING,
+                    callback=self._gpio_return,
+                    bouncetime=200,
+                )
+                print(f"[GPIO] Event detect added for return on pin {IR_BALL_RETURN}")
+                GPIO.add_event_detect(
+                    IR_TARGET_1,
+                    GPIO.RISING,
+                    callback=self._gpio_target1,
+                    bouncetime=200,
+                )
+                print(f"[GPIO] Event detect added for target IR on pin {IR_TARGET_1}")
+                GPIO.add_event_detect(
+                    BUTTON_START,
+                    GPIO.RISING,
+                    callback=self._gpio_start,
+                    bouncetime=300,
+                )
+                print(f"[GPIO] Event detect added for start on pin {BUTTON_START}")
+                GPIO.add_event_detect(
+                    BUTTON_FORCE_TURN,
+                    GPIO.RISING,
+                    callback=self._gpio_force,
+                    bouncetime=300,
+                )
+                print(f"[GPIO] Event detect added for force turn on pin {BUTTON_FORCE_TURN}")
+                GPIO.add_event_detect(
+                    BUTTON_RED_DISPENSE,
+                    GPIO.RISING,
+                    callback=self._gpio_dispense_red,
+                    bouncetime=300,
+                )
+                print(f"[GPIO] Event detect added for red dispense on pin {BUTTON_RED_DISPENSE}")
+                GPIO.add_event_detect(
+                    BUTTON_GREEN_DISPENSE,
+                    GPIO.RISING,
+                    callback=self._gpio_dispense_green,
+                    bouncetime=300,
+                )
+                print(f"[GPIO] Event detect added for green dispense on pin {BUTTON_GREEN_DISPENSE}")
+            except Exception as exc:
+                print(f"[GPIO] Failed to add event detection: {exc}")
+
+        # Start background polling for pressure sensors
+        threading.Thread(target=self._poll_pressure_sensors, daemon=True).start()
+        # Start the command interface if running in a terminal
+        threading.Thread(target=self._command_loop, daemon=True).start()
+
+    def _log(self, message: str):
+        """Helper to print debug messages with a consistent prefix."""
+        print(f"[Game] {message}")
+
+
+    def choose_next_target(self, team: Team) -> Optional[int]:
+        remaining = [t for t in range(1, NUM_TARGETS + 1) if t not in self.completed_targets[team]]
+        return random.choice(remaining) if remaining else None
+
+
+    def setup_ui(self):
+        self.root.title("Castles & Cans")
+        self.root.geometry("800x480")
+        self.root.configure(bg=BG_COLOR)
+
+        self.status_label = tk.Label(
+            self.root,
+            text="Press START",
+            font=TITLE_FONT,
+            fg=FG_COLOR,
+            bg=BG_COLOR,
+        )
+        self.status_label.pack(pady=20, expand=True, fill=tk.BOTH)
+
+        button_frame = tk.Frame(self.root, bg=BG_COLOR)
+        self.start_button = tk.Button(
+            button_frame,
+            text="Start / Reset",
+            command=self.start_game,
+            font=BUTTON_FONT,
+            bg=BUTTON_BG,
+            fg="white",
+        )
+        self.start_button.pack(side=tk.LEFT, padx=5)
+
+        self.force_next_button = tk.Button(
+            button_frame,
+            text="Force Next Turn",
+            command=self.next_turn,
+            font=BUTTON_FONT,
+            bg=BUTTON_BG,
+            fg="white",
+        )
+        self.force_next_button.pack(side=tk.LEFT, padx=5)
+
+        self.dispense_red = tk.Button(
+            button_frame,
+            text="Dispense Red",
+            command=lambda: self.dispense_beer(Team.RED),
+            font=BUTTON_FONT,
+            bg="firebrick4",
+            fg="white",
+        )
+        self.dispense_red.pack(side=tk.LEFT, padx=5)
+
+        self.dispense_green = tk.Button(
+            button_frame,
+            text="Dispense Green",
+            command=lambda: self.dispense_beer(Team.GREEN),
+            font=BUTTON_FONT,
+            bg="dark green",
+            fg="white",
+        )
+        self.dispense_green.pack(side=tk.LEFT, padx=5)
+        button_frame.pack(pady=10)
+
+        self.progress_frame = tk.Frame(self.root, bg=BG_COLOR)
+        self.progress_labels = []
+        for _ in range(NUM_TARGETS):
+            lbl = tk.Label(
+                self.progress_frame,
+                text="○",
+                font=PROGRESS_FONT,
+                bg=BG_COLOR,
+                fg=FG_COLOR,
+            )
+            lbl.pack(side=tk.LEFT, padx=4)
+            self.progress_labels.append(lbl)
+        self.progress_frame.pack(pady=5)
+
+        self.target_label = tk.Label(
+            self.root,
+            text="",
+            font=LABEL_FONT,
+            fg=FG_COLOR,
+            bg=BG_COLOR,
+        )
+        self.target_label.pack(pady=5)
+
+
+
+        # Fullscreen overlay for photos with centered text
+        self.overlay = tk.Frame(self.root, bg=BG_COLOR)
+        self.overlay_image = tk.Label(self.overlay, bg=BG_COLOR)
+        self.overlay_image.pack(fill=tk.BOTH, expand=True)
+        self.overlay_text = tk.Label(
+            self.overlay,
+            text="",
+            font=TITLE_FONT,
+            fg=FG_COLOR,
+            bg=BG_COLOR,
+        )
+        self.overlay_text.place(relx=0.5, rely=0.5, anchor="center")
+        self.overlay.place_forget()
+        self._anim_id = None
+
+        # Ensure key events go to the root window
+        self.root.focus_set()
+
+    def start_game(self):
+        self._log("Game started - flipping coin")
+        self.hw.reset_servos()
+        self.state = GameState.COIN_FLIP
+        self.status_label.config(text="Flipping coin...")
+        self.target_label.config(text="")
+        self.hide_overlay()
+        self.chug_photo = None
+        self.ball_in_play = False
+        self.completed_targets = {Team.RED: set(), Team.GREEN: set()}
+        self.current_target = {Team.RED: None, Team.GREEN: None}
+        self.watchtower_active = False
+        self.hw.rotate_servo(SERVO_3, 90)  # reset watchtower
+        self.hw.set_theme_lighting(None)
+        # choose initial targets
+        for team in Team:
+            self.current_target[team] = self.choose_next_target(team)
+        self.hw.restore_targets(Team.RED, 0)
+        self.hw.restore_targets(Team.GREEN, 0)
+        self.root.after(1000, self.finish_coin_flip)
+
+    def finish_coin_flip(self):
+        self.current_team = random.choice([Team.RED, Team.GREEN])
+        self._log(f"{self.current_team.value} won the coin flip")
+        self.status_label.config(
+            text=f"{self.current_team.value} starts - hit target {self.current_target[self.current_team]}"
+        )
+        self.hw.set_theme_lighting(self.current_team)
+        self.hw.restore_targets(self.current_team, len(self.completed_targets[self.current_team]))
+        self.state = GameState.PLAYER_TURN
+        self.update_progress()
+
+    def hit_target(self, target: int):
+        """Register a target hit. Always output the hardware event.
+
+        Progress only advances when the game is in ``PLAYER_TURN`` state and
+        the correct target for the current team is hit. Other hits merely show a
+        message so key presses are visible when testing.
+        """
+        self._log(f"Target {target} hit")
+        self.hw.hit_target(target)
+        self.capture_image("hit")
+
+        if self.state != GameState.PLAYER_TURN:
+            # Show feedback even if the hit occurs at the wrong time
+            self.status_label.config(text=f"Target {target} hit (not your turn)")
+            return
+
+        if target == self.current_target[self.current_team]:
+            self.complete_target(target)
+        else:
+            self.hw.play_sound(SoundEffect.NEUTRAL_HIT)
+            self.status_label.config(text=f"Target {target} hit out of order - await tunnel")
+            self.awaiting_tunnel = False
+            self.state = GameState.AWAITING_TUNNEL
+
+    def complete_target(self, target: int):
+        """Mark the target complete and prepare for the tunnel."""
+        self._log(f"Target {target} completed by {self.current_team.value}")
+        self.hw.play_sound(SoundEffect.TARGET_HIT)
+        color = LedColor.RED if self.current_team == Team.RED else LedColor.GREEN
+        self.hw.set_target_led(target, color)
+        self.completed_targets[self.current_team].add(target)
+        self.update_progress()
+        if len(self.completed_targets[self.current_team]) >= NUM_TARGETS:
+            self.win_game()
+            return
+        self.current_target[self.current_team] = self.choose_next_target(self.current_team)
+        self.status_label.config(text=f"Target {target} hit! Await tunnel")
+        self.state = GameState.AWAITING_TUNNEL
+        self.awaiting_tunnel = True
+
+    def win_game(self):
+        """Handle a victory for the current team."""
+        self._log(f"{self.current_team.value} wins the game")
+        self.state = GameState.GAME_OVER
+        self.ball_in_play = False
+        self.status_label.config(text=f"{self.current_team.value} WINS!")
+        self.hw.play_sound(SoundEffect.VICTORY)
+        self.hw.drop_gate()
+        self.hw.play_sound(SoundEffect.GATE_BREACH)
+        self.hw.raise_pong_platform()
+        self.hw.set_theme_lighting(None)
+
+    def start_chug_phase(self):
+        """Begin the chug phase once the ball launches."""
+        self._log("Chug phase started")
+        self.state = GameState.CHUG
+        self.hw.start_chug(self.current_team)
+        self.hw.play_sound(SoundEffect.CHUG_START)
+        self.status_label.config(text=f"{self.current_team.value} CHUG!")
+        # Capture a chug photo after a short delay without blocking
+        self.root.after(2000, lambda: self.capture_image('chug', show=False, store_attr='chug_photo'))
+
+    def end_chug_phase(self):
+        self._log("Chug phase ended")
+        self.hw.play_sound(SoundEffect.CHUG_STOP)
+        self.hw.stop_chug(self.current_team)
+        self.next_turn()
+
+    def launch_ball(self):
+        """Fire the plunger when the game is ready."""
+        if self.state != GameState.AWAITING_LAUNCH:
+            return
+        self._log("Ball launched")
+        self.hw.launch_plunger()
+        self.ball_in_play = True
+        if self.awaiting_tunnel:
+            self.start_chug_phase()
+        else:
+            self.state = GameState.BALL_LAUNCHED
+            self.status_label.config(text="Ball launched")
+        self.hide_overlay()
+
+    def tunnel_triggered(self):
+        """Handle the ball entering the tunnel."""
+        if self.state not in (
+            GameState.AWAITING_TUNNEL,
+            GameState.BALL_LAUNCHED,
+            GameState.PLAYER_TURN,
+        ):
+            return
+
+        self.hw.activate_tunnel(1)
+        self._log("Tunnel triggered")
+        self.ball_in_play = False
+        self.state = GameState.AWAITING_LAUNCH
+
+        if self.awaiting_tunnel:
+            self.status_label.config(text=f"{self.current_team.value} target cleared! Preparing launch")
+        else:
+            self.status_label.config(text="Ball entered tunnel")
+
+        self.root.after(2000, self.ready_to_launch)
+
+    def ready_to_launch(self):
+        """Display a prompt that the plunger may be fired."""
+        if self.state == GameState.AWAITING_LAUNCH:
+            self._log("Ready to launch")
+            self.status_label.config(text="Ready to launch - press L")
+
+    def dispense_beer(self, team: Team):
+        self._log(f"Dispense beer for {team.value}")
+        self.prev_status = self.status_label.cget("text")
+        self.status_label.config(text=f"Dispensing beer for {team.value}")
+        self.hw.play_sound(SoundEffect.DISPENSE)
+        self.hw.dispense(team)
+        self.root.after(2000, lambda: self.status_label.config(text=self.prev_status))
+
+    def clear_tube(self):
+        """Run the fan to clear the ball return tube."""
+        self._log("Clearing tube")
+        self.prev_status = self.status_label.cget("text")
+        self.status_label.config(text="Clearing tube...")
+        self.hw.blow_fan()
+        self.root.after(5000, lambda: self.status_label.config(text=self.prev_status))
+
+    def ball_returned(self):
+        self._log("Ball returned")
+        if self.state == GameState.CHUG:
+            self.hw.play_sound(SoundEffect.CHUG_STOP)
+            self.hw.stop_chug(self.current_team)
+            self.status_label.config(text="Stop chugging")
+            self.ball_in_play = False
+            if self.chug_photo:
+                self.show_overlay(self.chug_photo, "")
+            if self.state != GameState.GAME_OVER:
+                self.root.after(2000, self.next_turn)
+        elif self.ball_in_play:
+            self.status_label.config(text="Ball returned")
+            self.ball_in_play = False
+            if self.state != GameState.GAME_OVER:
+                self.root.after(1000, self.next_turn)
+
+    def next_turn(self):
+        if self.current_team is None:
+            return
+        self._log("Switching turn")
+        self.current_team = Team.GREEN if self.current_team == Team.RED else Team.RED
+        self.current_target[self.current_team] = self.choose_next_target(self.current_team)
+        self.status_label.config(
+            text=f"{self.current_team.value} turn - hit target {self.current_target[self.current_team]}"
+        )
+        self.hw.set_theme_lighting(self.current_team)
+        self.hw.restore_targets(self.current_team, len(self.completed_targets[self.current_team]))
+        self.update_progress()
+        self.ball_in_play = False
+        self.awaiting_tunnel = False
+        self.chug_photo = None
+        self.hide_overlay()
+        self.state = GameState.PLAYER_TURN
+
+    def update_progress(self):
+        hits = len(self.completed_targets[self.current_team])
+        for i, lbl in enumerate(self.progress_labels):
+            if i < hits:
+                color = 'red' if self.current_team == Team.RED else 'green'
+                lbl.config(text='●', fg=color)
+            else:
+                lbl.config(text='○', fg=FG_COLOR)
+        next_t = self.current_target[self.current_team]
+        self.target_label.config(text=f"Next target: {next_t if next_t else '-'}")
+
+    def show_overlay(self, photo, text: str):
+        """Display a fullscreen image with optional text."""
+        self.overlay_image.config(image=photo)
+        self.overlay_image.image = photo
+        self.overlay_text.config(text=text)
+        if self._anim_id:
+            self.root.after_cancel(self._anim_id)
+        self.overlay.place(x=0, y=self.root.winfo_height(), relwidth=1, relheight=1)
+        self.overlay_text.lift()
+        self._anim_id = None
+        self._slide_overlay(0)
+
+    def _slide_overlay(self, target_y: int, duration: int = 400):
+        """Smoothly slide the overlay to ``target_y`` over ``duration`` ms."""
+        start_y = self.overlay.winfo_y()
+        distance = target_y - start_y
+        steps = max(1, int(duration / 16))
+        step = distance / steps
+
+        def animate(count=0):
+            y = start_y + step * count
+            self.overlay.place(y=int(y), relwidth=1, relheight=1)
+            if count < steps:
+                self._anim_id = self.root.after(16, animate, count + 1)
+            else:
+                self.overlay.place(y=target_y, relwidth=1, relheight=1)
+                if target_y >= self.root.winfo_height():
+                    self.overlay.place_forget()
+                self._anim_id = None
+
+        animate()
+
+    def hide_overlay(self):
+        """Slide the overlay off the screen."""
+        if self.overlay.winfo_ismapped():
+            if self._anim_id:
+                self.root.after_cancel(self._anim_id)
+                self._anim_id = None
+            self._slide_overlay(self.root.winfo_height())
+
+    def capture_image(self, prefix: str, show: bool = True, store_attr: Optional[str] = None):
+        """Capture an image asynchronously and optionally show it."""
+
+        def worker():
+            path = self.camera.capture_image(prefix)
+            photo = None
+            if Image and ImageTk:
+                try:
+                    img = Image.open(path)
+                    img = img.resize((800, 480))
+                    photo = ImageTk.PhotoImage(img)
+                except Exception as exc:
+                    print(f"Failed to load image {path}: {exc}")
+            else:
+                print("[Init] Pillow not available - skipping image preview")
+
+            self.drive.upload(path)
+            if store_attr is not None:
+                setattr(self, store_attr, photo)
+            if show and photo:
+                self.root.after(0, lambda: [self.show_overlay(photo, ""), self.root.after(3000, self.hide_overlay)])
+
+        threading.Thread(target=worker, daemon=True).start()
+
+    # GPIO event callbacks run in a background thread; schedule on the Tk loop
+    def _gpio_tunnel(self, channel):
+        print(f"[GPIO] Tunnel sensor triggered on pin {channel}")
+        self.root.after(0, self.tunnel_triggered)
+
+    def _gpio_return(self, channel):
+        print(f"[GPIO] Ball return sensor triggered on pin {channel}")
+        self.root.after(0, self.ball_returned)
+
+    def _gpio_target1(self, channel):
+        print(f"[GPIO] IR target sensor triggered on pin {channel}")
+        self.root.after(0, self.watchtower_ir_triggered)
+
+    def _gpio_start(self, channel):
+        print(f"[GPIO] Start button pressed on pin {channel}")
+        self.root.after(0, self.start_game)
+
+    def _gpio_force(self, channel):
+        print(f"[GPIO] Force turn button pressed on pin {channel}")
+        self.root.after(0, self.next_turn)
+
+    def _gpio_dispense_red(self, channel):
+        print(f"[GPIO] Red dispense button pressed on pin {channel}")
+        self.root.after(0, lambda: self.dispense_beer(Team.RED))
+
+    def _gpio_dispense_green(self, channel):
+        print(f"[GPIO] Green dispense button pressed on pin {channel}")
+        self.root.after(0, lambda: self.dispense_beer(Team.GREEN))
+
+    def _poll_pressure_sensors(self):
+        """Continuously check the pressure sensors for hits."""
+        while True:
+            for ch in PRESSURE_CHANNELS:
+                value = self.hw.read_adc(ch)
+                threshold = self.hw.pressure_sensitivity.get(ch, PRESSURE_SENSITIVITY_DEFAULT)
+                active = value > threshold
+                if active and not self._pressure_state[ch]:
+                    self._pressure_state[ch] = True
+                    self.pressure_hits[ch] += 1
+                    print(f"[Pressure] Registered hit on channel {ch}")
+                    if ch == 0:
+                        self.root.after(0, self.watchtower_pressure_hit)
+                elif not active and self._pressure_state[ch]:
+                    self._pressure_state[ch] = False
+            time.sleep(0.05)
+
+    def watchtower_pressure_hit(self):
+        if (
+            self.state == GameState.PLAYER_TURN
+            and self.current_target[self.current_team] == 1
+            and not self.watchtower_active
+        ):
+            self._log("Watchtower pressure hit")
+            self.watchtower_active = True
+            self.status_label.config(text="Watchtower struck!")
+            # Rotate servo slowly to topple the tower (90 -> 50)
+            self.hw.rotate_servo(SERVO_3, 50, speed=20)
+
+    def watchtower_ir_triggered(self):
+        if self.watchtower_active and self.current_target[self.current_team] == 1:
+            self._log("Watchtower IR complete")
+            self.hw.rotate_servo(SERVO_3, 90, speed=20)
+            self.watchtower_active = False
+            self.complete_target(1)
+
+    def handle_key(self, event):
+        key = event.keysym.lower()
+        if key == 's':
+            self.start_game()
+        elif key == 'n':
+            self.next_turn()
+        elif key == 'r':
+            self.dispense_beer(Team.RED)
+        elif key == 'g':
+            self.dispense_beer(Team.GREEN)
+        elif key in ['1', '2', '3', '4', '5', '6', '7']:
+            self.hit_target(int(key))
+        elif key == 'y':
+            self.watchtower_ir_triggered()
+        elif key == 't':
+            self.tunnel_triggered()
+        elif key == 'b':
+            self.ball_returned()
+        elif key == 'l':
+            self.launch_ball()
+        elif key == 'f':
+            self.clear_tube()
+
+    # ---------------- Command Interface -----------------
+    def _command_loop(self):
+        """Read commands from stdin for manual testing."""
+        while True:
+            try:
+                line = input()
+            except EOFError:
+                break
+            if not line:
+                continue
+            result = self.process_command(line.strip())
+            if result == "EXIT":
+                break
+
+    def _print_help(self):
+        """Print available commands for the console interface."""
+        print("Available commands:")
+        print("  help                         Show this help message")
+        print("  servo <n> <angle> [speed]    Rotate servo n to angle (0-180)")
+        print("  calibrate <n> <angle>        Set servo n's starting angle")
+        print("  sensitivity <ch> <val>       Set pressure sensor threshold")
+        print("  hit <n>                      Trigger target n")
+        print("  tunnel                       Simulate tunnel sensor")
+        print("  launch                       Fire the plunger")
+        print("  return                       Simulate ball return")
+        print("  dispense <red|green>         Dispense beer for a team")
+        print("  watchtower_pressure (wp)     Trigger watchtower pressure sensor")
+        print("  watchtower_ir (wi)           Trigger watchtower IR sensor")
+        print("  start | reset                Start or reset the game")
+        print("  exit                         Quit command mode")
+
+    def process_command(self, cmd: str):
+        """Handle a console command."""
+        parts = cmd.split()
+        if not parts:
+            return
+        action = parts[0].lower()
+        if action in ("help", "?"):
+            self._print_help()
+        elif action in ("watchtower_pressure", "wp"):
+            self.watchtower_pressure_hit()
+        elif action in ("watchtower_ir", "wi"):
+            self.watchtower_ir_triggered()
+        elif action == "servo" and len(parts) >= 3:
+            try:
+                num = int(parts[1])
+                angle = float(parts[2])
+                speed = float(parts[3]) if len(parts) >= 4 else 180.0
+            except ValueError:
+                print("[Cmd] Usage: servo <1-8> <angle> [speed]")
+                return
+            pin = self.servo_map.get(num)
+            if not pin:
+                print(f"[Cmd] Unknown servo {num}")
+                return
+            self.hw.set_servo_angle(pin, angle, speed)
+        elif action == "calibrate" and len(parts) >= 3:
+            try:
+                num = int(parts[1])
+                angle = float(parts[2])
+            except ValueError:
+                print("[Cmd] Usage: calibrate <servo> <angle>")
+                return
+            pin = self.servo_map.get(num)
+            if not pin:
+                print(f"[Cmd] Unknown servo {num}")
+                return
+            angle = max(0, min(angle, self.hw.MAX_ANGLE))
+            self.hw.servo_start[pin] = angle
+            self.hw.set_servo_angle(pin, angle)
+            self.hw._save_servo_state()
+        elif action == "sensitivity" and len(parts) >= 3:
+            try:
+                ch = int(parts[1])
+                value = int(parts[2])
+            except ValueError:
+                print("[Cmd] Usage: sensitivity <channel> <threshold>")
+                return
+            if ch not in PRESSURE_CHANNELS:
+                print(f"[Cmd] Unknown channel {ch}")
+                return
+            self.hw.set_pressure_sensitivity(ch, value)
+            print(f"[Cmd] Channel {ch} sensitivity set to {value}")
+        elif action == "hit" and len(parts) >= 2:
+            try:
+                target = int(parts[1])
+            except ValueError:
+                print("[Cmd] Usage: hit <target>")
+                return
+            self.hit_target(target)
+        elif action == "tunnel":
+            self.tunnel_triggered()
+        elif action == "return":
+            self.ball_returned()
+        elif action == "launch":
+            self.launch_ball()
+        elif action in ("start", "reset"):
+            self.start_game()
+        elif action == "dispense" and len(parts) >= 2:
+            team = parts[1].lower()
+            if team.startswith('r'):
+                self.dispense_beer(Team.RED)
+            elif team.startswith('g'):
+                self.dispense_beer(Team.GREEN)
+            else:
+                print("[Cmd] Usage: dispense <red|green>")
+        elif action == "exit":
+            return "EXIT"
+        else:
+            print(f"[Cmd] Unknown command: {cmd}")
+
+
+if __name__ == "__main__":
+    try:
+        root = tk.Tk()
+    except tk.TclError as exc:
+        print(f"[Error] Tk initialization failed: {exc}")
+        sys.exit(1)
+    game = CastlesAndCansGame(root)
+    root.mainloop()


### PR DESCRIPTION
## Summary
- clamp servo angles to 0–180° and drop continuous spin
- remember servo start angles and allow calibration with `calibrate` command
- fix NameError in servo rotation
- add help command and servo speed control
- allow per-channel pressure sensor sensitivity with persistence

## Testing
- `python3 -m py_compile src/game.py`
- `python3 src/game.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_684db4fd345c83339821091ae7ecf14e